### PR TITLE
Magisk Module Uninstaller Template v1.6

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -49,7 +49,6 @@ ZIP=$3
 readlink /proc/$$/fd/$OUTFD 2>/dev/null | grep /tmp >/dev/null
 if [ "$?" -eq "0" ]; then
   OUTFD=0
-
   for FD in `ls /proc/$$/fd`; do
     readlink /proc/$$/fd/$FD 2>/dev/null | grep pipe >/dev/null
     if [ "$?" -eq "0" ]; then
@@ -97,30 +96,6 @@ $BOOTMODE && ! is_mounted /magisk && abort "! Magisk is not activated!"
 
 # We need busybox/binaries to be setup
 $BOOTMODE && boot_actions || recovery_actions
-
-# Dummy MODID
-MODID=UnInstall
-
-# Dummy print_modname() Fn
-print_modname()
-{
-  # Dummy print_modname() Fn
-  ui_print "*******************************"
-  ui_print "    Magisk Module Uninstall    "
-  ui_print "*******************************"
-}
-
-# Dummy script_before_uninstall() Fn
-script_before_uninstall()
-{
-  # Dummy script_before_uninstall() Fn
-}
-
-# Dummy script_after_uninstall() Fn
-script_after_uninstall()
-{
-  # Dummy script_after_uninstall() Fn
-}
 
 ##########################################################################################
 # Preparation

--- a/README.md
+++ b/README.md
@@ -115,5 +115,12 @@ Thanking You for the Same.
 - Removed all Un-Necessary Variable's .  
 - ReNamed Variable `INSTALLER` to `UNINSTALLER` .   
 - Close to Magisk Module Template v1400 ! .  
+   
+#### v1.6 ####  
+- Updated `README` .  
+- Updated `update-binary` .  
+- Removed All `Dummy` Function & Variable coz of below Bug & Thanks to `TheComputerGuy96` .  
+- Fixed a Major Bug where Script was Executing in TWRP 3.0.2-0 but didn't in TWRP 3.1.1-0 .  
+- Now the *ZIP* will Flash/Execute as Intended , Sorry that I realized it too late .  
   
 .


### PR DESCRIPTION
v1.6
- Updated `README` .  
- Updated `update-binary` .  
- Removed All `Dummy` Function & Variable coz of below Bug & Thanks to `TheComputerGuy96` .  
- Fixed a Major Bug where Script was Executing in TWRP 3.0.2-0 but didn't in TWRP 3.1.1-0 .  
- Now the *ZIP* will Flash/Execute as Intended , Sorry that I realized it too late .